### PR TITLE
new:dev:#5:Support publish to Qubole's maven repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@
 
 **Dr. Elephant** is a performance monitoring and tuning tool for Hadoop and Spark. It automatically gathers all the metrics, runs analysis on them, and presents them in a simple way for easy consumption. Its goal is to improve developer productivity and increase cluster efficiency by making it easier to tune the jobs. It analyzes the Hadoop and Spark jobs using a set of pluggable, configurable, rule-based heuristics that provide insights on how a job performed, and then uses the results to make suggestions about how to tune the job to make it perform more efficiently.
 
+# Qubole Support
+
+## Release
+
+    sbt release -Daws.accessKeyId=XXXXXX -Daws.secretKey=XXXXXX
+
 ## Documentation
 
 For more information on Dr. Elephant, [see the wiki](https://github.com/linkedin/dr-elephant/wiki).

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,13 @@ unmanagedClasspath in Compile ++= update.value.select(configurationFilter("compi
 
 playJavaSettings
 
-publishTo := Some(Resolver.file("file",  new File(Path.userHome.absolutePath+"/.m2/repository")))
+publishTo :=  {
+  val maven = "s3://maven-qubole/"
+  if (isSnapshot.value)
+    Some("snapshots" at maven + "snapshot") 
+  else
+    Some("releases"  at maven + "release")
+}
 
 publishMavenStyle := true
 

--- a/build.sbt
+++ b/build.sbt
@@ -19,8 +19,6 @@ import Dependencies._
 
 name := "dr-elephant"
 
-version := "2.0.6-qds-0.2.0-SNAPSHOT"
-
 organization := "com.linkedin.drelephant"
 
 javacOptions in Compile ++= Seq("-source", "1.8", "-target", "1.8")

--- a/project/build.properties
+++ b/project/build.properties
@@ -14,4 +14,4 @@
 # the License.
 #
 
-sbt.version=0.13.0
+sbt.version=0.13.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -26,3 +26,6 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % Option(System.getProperty("pla
 addSbtPlugin("de.johoop" % "jacoco4sbt" % "2.1.6")
 
 addSbtPlugin("com.frugalmechanic" % "fm-sbt-s3-resolver" % "0.9.0")
+
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.4")
+

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -24,3 +24,5 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % Option(System.getProperty("pla
 
 // Jacoco code coverage plugin
 addSbtPlugin("de.johoop" % "jacoco4sbt" % "2.1.6")
+
+addSbtPlugin("com.frugalmechanic" % "fm-sbt-s3-resolver" % "0.9.0")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.0.6-qds-0.3.0-SNAPSHOT"
+version in ThisBuild := "2.0.6-qds-0.3.1"

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "2.0.6-qds-0.2.0"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.0.6-qds-0.3.1"
+version in ThisBuild := "2.0.6-qds-0.3.2-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.0.6-qds-0.2.0"
+version in ThisBuild := "2.0.6-qds-0.3.0-SNAPSHOT"


### PR DESCRIPTION
Fix #5 

The first step to automate releases is to publish to Qubole's public maven repo in s3://maven-qubole.
https://github.com/frugalmechanic/fm-sbt-s3-resolver is used to publish to S3.

The second step is to use sbt-release and version, tag and re-version correctly. 
